### PR TITLE
Remove usage of max_glyphs with Label

### DIFF
--- a/adafruit_simple_text_display.py
+++ b/adafruit_simple_text_display.py
@@ -166,7 +166,6 @@ class SimpleTextDisplay:
             title = label.Label(
                 self._font,
                 text=title,
-                max_glyphs=title_length,
                 color=title_color,
                 scale=title_scale,
             )


### PR DESCRIPTION
Remove usage of `max_glyphs` now that it has been removed from `Adafruit_CircuitPython_Display_Text`
https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/releases/tag/2.20.0

Tested on a PyPortal with `7.0.0-alpha-5`

@kattni
It's possible that the `title-length` parameter is no longer needed following the removal of `max_glyphs`. I've left it alone for now.