### PR TITLE
Font-based row height

### DIFF
--- a/adafruit_simple_text_display.py
+++ b/adafruit_simple_text_display.py
@@ -21,8 +21,6 @@ Any microcontroller with a built-in display, or an external display.
 
 * Adafruit CircuitPython firmware for the supported boards:
   https://github.com/adafruit/circuitpython/releases
-
- * Adafruit's Register library: https://github.com/adafruit/Adafruit_CircuitPython_Display_Text
 """
 
 import board
@@ -62,9 +60,9 @@ class SimpleTextDisplay:
         self,
         title=None,
         title_color=(255, 255, 255),
-        title_scale=1,
-        title_length=80,
-        text_scale=1,
+        title_scale: int = 1,
+        title_length: int = 80,
+        text_scale: int = 1,
         font=None,
         colors=None,
         display=None,
@@ -78,39 +76,37 @@ class SimpleTextDisplay:
         must include the data call in the loop by using ``.text =``. For example, if setup is saved
         as ``temperature_data = simple_text_display()`` then ``temperature_data[0].text =
         microcontroller.cpu.temperature`` must be inside the ``while True:`` loop for the
-        temperature data displayed to update as the values change. You must call ``show()`` at the
+        temperature data displayed to update as the values change. You must call `show()` at the
         end of the list for anything to display. See example below for usage.
 
-        :param str title: The title displayed above the data. Set ``title="Title text"`` to provide
-                          a title. Defaults to None.
-        :param title_color: The color of the title. Not necessary if no title is provided. Defaults
-                            to white (255, 255, 255).
+        :param None,str title: The title displayed above the data. Set ``title="Title text"`` to
+            provide a title. Defaults to `None`.
+        :param None,Tuple(int,int,int) title_color: The color of the title. Not necessary if no
+            title is provided. Defaults to white (255, 255, 255).
         :param int title_scale: Scale the size of the title. Not necessary if no title is provided.
-                                Defaults to 1.
+            Defaults to 1.
         :param int title_length: The maximum number of characters allowed in the title. Only
-                                 necessary if the title is longer than the default 80 characters.
-                                 Defaults to 80.
+            necessary if the title is longer than the default 80 characters. Defaults to 80.
         :param int text_scale: Scale the size of the data lines. Scales the title as well.
-                               Defaults to 1.
-        :param str font: The font to use to display the title and data. Defaults to
-                         ``terminalio.FONT``.
-        :param colors: A list of colors for the lines of data on the display. If you provide a
-                       single color, all lines will be that color. Otherwise it will cycle through
-                       the list you provide if the list is less than the number of lines displayed.
-                       Default colors are used if ``colors`` is not set. For example, if creating
-                       two lines of data, ``colors=((255, 255, 255), (255, 0, 0))`` would set the
-                       first line white and the second line red, and if you created four lines of
-                       data with the same setup, it would alternate white and red. You can also use
-                       the colors built into the library. For example, if you import the library
-                       as ``from adafruit_simple_text_display import SimpleTextDisplay``, you can
-                       indicate the colors as follows:
-                       ``colors=(SimpleDisplayText.WHITE, SimpleDisplayText.RED)``.
-        :param display: The display object. Defaults to assuming a built-in display. To use with an
-                        external display, instantiate the display object and provide it here.
-                        Defaults to ``board.DISPLAY``.
+            Defaults to 1.
+        :param ~fontio.BuiltinFont,~adafruit_bitmap_font.bdf.BDF,~adafruit_bitmap_font.pcf.PCF font:
+            The font to use to display the title and data. Defaults to `terminalio.FONT`.
+        :param None,Tuple(Tuple(int,int,int),...) colors: A list of colors for the lines of data
+            on the display. If you provide a single color, all lines will be that color. Otherwise
+            it will cycle through the list you provide if the list is less than the number of lines
+            displayed. Default colors are used if ``colors`` is not set. For example, if creating
+            two lines of data, ``colors=((255, 255, 255), (255, 0, 0))`` would set the first line
+            white and the second line red, and if you created four lines of data with the same
+            setup, it would alternate white and red. You can also use the colors built into the
+            library. For example, if you import the library as
+            ``from adafruit_simple_text_display import SimpleTextDisplay``, you can indicate the
+            colors as follows: ``colors=(SimpleDisplayText.WHITE, SimpleDisplayText.RED)``.
+        :param None,~displayio.Display display: The display object. Defaults to assuming a built-in
+            display. To use with an external display, instantiate the display object and provide it
+            here. Defaults to ``board.DISPLAY``.
 
         This example displays two lines with temperature data in C and F on the display.
-        Remember to call ``show()`` after the list to update the display.
+        Remember to call `show()` after the list to update the display.
 
         .. code-block:: python
 
@@ -149,9 +145,7 @@ class SimpleTextDisplay:
         if display is None:
             display = board.DISPLAY
         self._display = display
-        self._font = terminalio.FONT
-        if font:
-            self._font = font
+        self._font = font if font else terminalio.FONT
 
         self.text_group = displayio.Group(scale=text_scale)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,10 @@ extensions = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.4", None),
     "CircuitPython": ("https://circuitpython.readthedocs.io/en/latest/", None),
+    "Adafruit_CircuitPython_Bitmap_Font": (
+        "https://circuitpython.readthedocs.io/projects/bitmap-font/en/latest/",
+        None,
+    ),
 }
 
 # Show the docstring from both the class and its __init__() method.


### PR DESCRIPTION
Add dynamic row heights based on font used. (Closes #3)
*The row heights are almost certainly different to the previous version. This may affect some deployed code.*

Deprecate `title_length`, ignore it for now. It is no longer needed with the update to `Adafruit_CircuitPython_Display_Text` removing `max_glyphs`.

Refactor the scaling so that the `text_scale` is not a multiple of the `title_scale`.

Correctly add multiple rows with the color-cycling effect. Previously all new rows had the same color.

Tested on Pynt with `7.0.0-alpha.5` and the following code, testing both fonts in different runs:
```python
import microcontroller
import terminalio
from adafruit_bitmap_font import bitmap_font
from adafruit_simple_text_display import SimpleTextDisplay

FONT = bitmap_font.load_font("/fonts/LibreBodoniv2002-Bold-27.bdf")  # A big font
FONT = terminalio.FONT  # A small font
temperature_data = SimpleTextDisplay(
    title="Temperature Data!", title_scale=1, font=FONT, text_scale=2
)

temperature_data[14].text = "Row 14"
temperature_data[13].text = "Row 13"
temperature_data[12].text = "Row 12"
temperature_data[11].text = "Row 11"
temperature_data[10].text = "Row 10"
temperature_data[9].text = "Row 9"
temperature_data[8].text = "Row 8"
temperature_data[7].text = "Row 7"
temperature_data[6].text = "Row 6"
temperature_data[5].text = "Row 5"
temperature_data[4].text = "Row 4"
temperature_data[3].text = "Row 3"
temperature_data[2].text = "Row 2"
temperature_data[1].text = "Row 1"
temperature_data[0].text = "Row 0"

while True:
    temperature_data[0].text = "Temperature: {:.2f} degrees C".format(
        microcontroller.cpu.temperature
    )
    temperature_data[1].text = "Temperature: {:.2f} degrees F".format(
        (microcontroller.cpu.temperature * (9 / 5) + 32)
    )
    temperature_data.show()
```